### PR TITLE
Small typo

### DIFF
--- a/src/main/java/net/daboross/bukkitdev/redstoneclockdetector/commands/TeleportCommand.java
+++ b/src/main/java/net/daboross/bukkitdev/redstoneclockdetector/commands/TeleportCommand.java
@@ -60,7 +60,7 @@ public class TeleportCommand extends AbstractCommand {
         }
         List<Entry<Location, Integer>> actList = this.plugin.getRedstoneActivityList();
         if (tpNum >= actList.size()) {
-            sender.sendMessage("Location num " + ChatColor.YELLOW + (tpNum + 1) + ChatColor.WHITE + "does not exist.");
+            sender.sendMessage("Location num " + ChatColor.YELLOW + (tpNum + 1) + " " + ChatColor.WHITE + "does not exist.");
         } else {
             player.teleport(actList.get(tpNum).getKey());
             if (player == sender) {


### PR DESCRIPTION
The message line becomes identical with this, correcting the typo.
https://github.com/Minebench/RedstoneClockDetector/blob/5855830e077b2af31bf82d742a230f3c7606491b/src/main/java/net/daboross/bukkitdev/redstoneclockdetector/commands/BreakCommand.java#L37
